### PR TITLE
feat: Create new homepage layout inspired by DeepMind

### DIFF
--- a/patterns/hero-deepmind.php
+++ b/patterns/hero-deepmind.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Title: Hero Section (DeepMind Inspired)
+ * Slug: twentytwentyfive/hero-deepmind
+ * Categories: banner, hero
+ * Description: A bold hero section inspired by the DeepMind homepage.
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Five
+ * @since Twenty Twenty-Five 1.0
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)">
+	<!-- wp:group {"layout":{"type":"constrained","contentSize":"800px"}} -->
+	<div class="wp-block-group">
+		<!-- wp:heading {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"huge"} -->
+		<h2 class="wp-block-heading has-text-align-center has-huge-font-size" style="font-style:normal;font-weight:700"><?php esc_html_e( 'Crie e edite imagens com Gemini 2.5 Flash Image', 'twentytwentyfive' ); ?></h2>
+		<!-- /wp:heading -->
+
+		<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
+		<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
+
+		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+		<div class="wp-block-buttons">
+			<!-- wp:button -->
+			<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Experimente no Gemini', 'twentytwentyfive' ); ?></a></div>
+			<!-- /wp:button -->
+			<!-- wp:button {"className":"is-style-outline"} -->
+			<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Saiba Mais', 'twentytwentyfive' ); ?></a></div>
+			<!-- /wp:button -->
+		</div>
+		<!-- /wp:buttons -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/patterns/models-showcase-deepmind.php
+++ b/patterns/models-showcase-deepmind.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Title: Models Showcase (DeepMind Inspired)
+ * Slug: twentytwentyfive/models-showcase-deepmind
+ * Categories: columns
+ * Description: A 4-column section to showcase AI models or services, inspired by the DeepMind homepage.
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Five
+ * @since Twenty Twenty-Five 1.0
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"margin":{"top":"0","bottom":"0"}},"backgroundColor":"accent-6"},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-accent-6-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+	<!-- wp:heading {"textAlign":"center","align":"wide"} -->
+	<h2 class="wp-block-heading alignwide has-text-align-center"><?php esc_html_e( 'Comece a Construir', 'twentytwentyfive' ); ?></h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
+	<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+
+	<!-- wp:columns {"align":"wide"} -->
+	<div class="wp-block-columns alignwide">
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full"} -->
+			<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/grid-flower-1.webp" alt="" style="aspect-ratio:1;object-fit:cover"/></figure>
+			<!-- /wp:image -->
+			<!-- wp:heading {"level":3} -->
+			<h3 class="wp-block-heading"><?php esc_html_e( 'Gemini', 'twentytwentyfive' ); ?></h3>
+			<!-- /wp:heading -->
+			<!-- wp:paragraph -->
+			<p><?php esc_html_e( 'Nossos modelos de IA mais inteligentes.', 'twentytwentyfive' ); ?></p>
+			<!-- /wp:paragraph -->
+			<!-- wp:paragraph -->
+			<p><a href="#"><?php esc_html_e( 'Saiba Mais', 'twentytwentyfive' ); ?></a></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full"} -->
+			<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/grid-flower-2.webp" alt="" style="aspect-ratio:1;object-fit:cover"/></figure>
+			<!-- /wp:image -->
+			<!-- wp:heading {"level":3} -->
+			<h3 class="wp-block-heading"><?php esc_html_e( 'Gemma', 'twentytwentyfive' ); ?></h3>
+			<!-- /wp:heading -->
+			<!-- wp:paragraph -->
+			<p><?php esc_html_e( 'Modelos abertos, leves e de última geração.', 'twentytwentyfive' ); ?></p>
+			<!-- /wp:paragraph -->
+			<!-- wp:paragraph -->
+			<p><a href="#"><?php esc_html_e( 'Saiba Mais', 'twentytwentyfive' ); ?></a></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full"} -->
+			<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/parthenon-square.webp" alt="" style="aspect-ratio:1;object-fit:cover"/></figure>
+			<!-- /wp:image -->
+			<!-- wp:heading {"level":3} -->
+			<h3 class="wp-block-heading"><?php esc_html_e( 'Veo', 'twentytwentyfive' ); ?></h3>
+			<!-- /wp:heading -->
+			<!-- wp:paragraph -->
+			<p><?php esc_html_e( 'Nosso modelo de geração de vídeo de última geração.', 'twentytwentyfive' ); ?></p>
+			<!-- /wp:paragraph -->
+			<!-- wp:paragraph -->
+			<p><a href="#"><?php esc_html_e( 'Saiba Mais', 'twentytwentyfive' ); ?></a></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full"} -->
+			<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/vash-gon-square.webp" alt="" style="aspect-ratio:1;object-fit:cover"/></figure>
+			<!-- /wp:image -->
+			<!-- wp:heading {"level":3} -->
+			<h3 class="wp-block-heading"><?php esc_html_e( 'Imagen', 'twentytwentyfive' ); ?></h3>
+			<!-- /wp:heading -->
+			<!-- wp:paragraph -->
+			<p><?php esc_html_e( 'Nosso principal modelo de conversão de texto em imagem.', 'twentytwentyfive' ); ?></p>
+			<!-- /wp:paragraph -->
+			<!-- wp:paragraph -->
+			<p><a href="#"><?php esc_html_e( 'Saiba Mais', 'twentytwentyfive' ); ?></a></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+</div>
+<!-- /wp:group -->

--- a/patterns/news-grid-deepmind.php
+++ b/patterns/news-grid-deepmind.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Title: News Grid (DeepMind Inspired)
+ * Slug: twentytwentyfive/news-grid-deepmind
+ * Categories: query
+ * Description: A grid of posts inspired by the DeepMind homepage news section.
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Five
+ * @since Twenty Twenty-Five 1.0
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+	<!-- wp:heading {"level":2,"align":"wide"} -->
+	<h2 class="wp-block-heading alignwide"><?php esc_html_e( 'Latest News', 'twentytwentyfive' ); ?></h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
+	<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+
+	<!-- wp:query {"queryId":1,"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"grid","columns":3},"align":"wide"} -->
+	<div class="wp-block-query alignwide">
+		<!-- wp:post-template -->
+			<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"16/9"} /-->
+			<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"5px"}},"layout":{"type":"flex"},"fontSize":"small"} -->
+			<div class="wp-block-group has-small-font-size">
+				<!-- wp:post-date /-->
+				<!-- wp:paragraph -->
+				<p>·</p>
+				<!-- /wp:paragraph -->
+				<!-- wp:post-terms {"term":"category"} /-->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:post-template -->
+	</div>
+	<!-- /wp:query -->
+</div>
+<!-- /wp:group -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,9 +1,10 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
-	<!-- wp:pattern {"slug":"twentytwentyfive/hidden-blog-heading"} /-->
-	<!-- wp:pattern {"slug":"twentytwentyfive/template-query-loop"} /-->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0"}}},"layout":{"type":"default"}} -->
+<main class="wp-block-group" style="margin-top:0">
+	<!-- wp:pattern {"slug":"twentytwentyfive/hero-deepmind"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfive/news-grid-deepmind"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfive/models-showcase-deepmind"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
This commit introduces a new homepage layout inspired by the `deepmind.google` website. It includes a new hero section, a news grid, and a models showcase section.

- Creates new patterns for the different sections of the homepage.
- Updates `templates/home.html` to use the new patterns.
- Uses existing images from the theme's `assets/images` directory.